### PR TITLE
148-m15-change-descripton-of-error-bool-==-true-on-cmcdqueryvalidator…

### DIFF
--- a/packages/cmcd-validator-library/src/tests/testCases/queryConfigTestCases.js
+++ b/packages/cmcd-validator-library/src/tests/testCases/queryConfigTestCases.js
@@ -140,9 +140,9 @@ export const queryConfigTestCases = [
       valid: false,
       errors: [
         {
-          type: 'incorrect-format',
+          type: 'wrong-type-value',
           key: 'su',
-          description: 'If the value is TRUE, the = and the value must be omitted',
+          description: 'The value for the key su must be a boolean.',
           value: '23',
         },
       ],

--- a/packages/cmcd-validator-library/src/tests/testCases/queryTestCases.js
+++ b/packages/cmcd-validator-library/src/tests/testCases/queryTestCases.js
@@ -277,10 +277,10 @@ export const queryTestCases = [
       valid: false,
       errors: [
         {
-          type: 'incorrect-format',
+          type: 'wrong-type-value',
           key: 'su',
           value: '"Qualabs"',
-          description: 'If the value is TRUE, the = and the value must be omitted',
+          description: 'The value for the key su must be a boolean.',
         },
       ],
       warnings: [],
@@ -297,10 +297,10 @@ export const queryTestCases = [
       valid: false,
       errors: [
         {
-          type: 'incorrect-format',
+          type: 'wrong-type-value',
           key: 'su',
           value: '23',
-          description: 'If the value is TRUE, the = and the value must be omitted',
+          description: 'The value for the key su must be a boolean.',
         },
       ],
       warnings: [],

--- a/packages/cmcd-validator-library/src/utils/formatFunctions.js
+++ b/packages/cmcd-validator-library/src/utils/formatFunctions.js
@@ -24,12 +24,15 @@ export const isStringCorrect = (key, value, errors, extendedkeyTypes) => {
 };
 
 export const isBooleanCorrect = (key, value, errors, extendedkeyTypes) => {
-  if (((extendedkeyTypes[key] === cmcdTypes.boolean) && value === 'true')
-    || (typeof value === 'undefined' && extendedkeyTypes[key] !== cmcdTypes.boolean)
-    || ((typeof value === cmcdTypes.number || (typeof value === cmcdTypes.string && value !== 'false'))
-    && extendedkeyTypes[key] === cmcdTypes.boolean)) {
+  if (((extendedkeyTypes[key] === cmcdTypes.boolean) && value === 'true')) {
     const description = 'If the value is TRUE, the = and the value must be omitted';
     errors.push(createError(errorTypes.incorrectFormat, key, value, description));
+    return false;
+  }
+  if ((typeof value === cmcdTypes.number || (typeof value === cmcdTypes.string && value !== 'false'))
+  && extendedkeyTypes[key] === cmcdTypes.boolean) {
+    const description = `The value for the key ${key} must be a boolean.`;
+    errors.push(createError(errorTypes.wrongTypeValue, key, value, description));
     return false;
   }
   return true;


### PR DESCRIPTION
…: changed the description in the booleaniscorrect function and fixed the corresponding test cases